### PR TITLE
Increase Sidekiq generic worker replica count from 3 to 5

### DIFF
--- a/manifests/applications/mastodon/overlays/toot.community/helm-values/mastodon.yaml
+++ b/manifests/applications/mastodon/overlays/toot.community/helm-values/mastodon.yaml
@@ -64,7 +64,7 @@ sidekiq:
   workers:
     - name: generic
       concurrency: 25
-      replicaCount: 3
+      replicaCount: 5
       queues:
         - default
         - mailers


### PR DESCRIPTION
Queues are lagging. Increasing the worker count as a temporary measure until I have time to consider implementing this dynamically. 