### PR TITLE
fix: Pin the version of plugin-barman-cloud to v0.5.0

### DIFF
--- a/manifests/applications/cloudnative-pg/kustomization.yaml
+++ b/manifests/applications/cloudnative-pg/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - rules.yaml
-  - https://github.com/cloudnative-pg/plugin-barman-cloud/kubernetes?ref=v0.5.0
+  - https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.5.0/manifest.yaml
 
 helmCharts:
   - name: cloudnative-pg


### PR DESCRIPTION
Fixes bad Kustomization deployment. Ref: https://github.com/cloudnative-pg/plugin-barman-cloud/issues/455