### PR TITLE
fix: increase memory limit for resources in varnish configuration

### DIFF
--- a/manifests/applications/mastodon/overlays/toot.community/helm-values/varnish-for-static.yaml
+++ b/manifests/applications/mastodon/overlays/toot.community/helm-values/varnish-for-static.yaml
@@ -14,7 +14,7 @@ resources:
     cpu: 13m
     memory: 512Mi
   limits:
-    memory: 512Mi
+    memory: 750Mi
     
 varnish:
   size: 50G


### PR DESCRIPTION
Was OOMKilled a couple of times.