### PR TITLE
Enable HSTS globally - Fixes #139

### DIFF
--- a/manifests/applications/ingress-nginx/helm-values.yaml
+++ b/manifests/applications/ingress-nginx/helm-values.yaml
@@ -24,6 +24,11 @@ controller:
     # Disable strict path validation, to work around a bug in ingress-nginx
     # https://github.com/kubernetes/ingress-nginx/issues/11176
     strict-validate-path-type: false
+    # HSTS configuration
+    hsts: "true"
+    hsts-include-subdomains: "true"
+    hsts-preload: "true"
+    hsts-max-age: "63072000" # 2 years
 
   extraArgs:
     enable-ssl-passthrough: ""


### PR DESCRIPTION
@jorijn do we want to enable this globally or are there cases where you wouldn't want this for certain applications? I reckon global is alright because everything runs on sub-domains of toot.community anyway.