### PR TITLE
Update kubectl image name and tag

### DIFF
--- a/manifests/applications/velero/kustomization.yaml
+++ b/manifests/applications/velero/kustomization.yaml
@@ -20,6 +20,6 @@ images:
   - name: velero/velero-plugin-for-aws
     newTag: v1.12.2@sha256:bef271808e0547bb70f69f0430cc73f7a2fa938949c50f7b31171018be967335
   - name: docker.io/bitnamilegacy/kubectl
-    newName: alpine/k8s
-    newTag: 1.34.0
+    newName: docker.io/bitnamisecure/kubectl
+    newTag: latest
     


### PR DESCRIPTION
Change the kubectl image name to a more secure repository and update the tag to the latest version.