### PR TITLE
Update Renovate configuration to set PR limits to zero

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "extends": [
     "config:best-practices"
   ],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "labels": [
     "renovate"
   ],


### PR DESCRIPTION
Adjust the Renovate configuration to remove limits on concurrent and hourly pull requests.