### PR TITLE
Update PostgreSQL image to version 17.6

### DIFF
--- a/manifests/applications/mastodon/overlays/toot.community/database-cluster.yaml
+++ b/manifests/applications/mastodon/overlays/toot.community/database-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: database
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.9
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.6
 
   storage:
     size: 550Gi


### PR DESCRIPTION
Upgrade the PostgreSQL image used in the deployment to version 17.6 for improved performance and security.