### PR TITLE
Update barman-cloud plugin manifest URL to v0.7.0

### DIFF
--- a/manifests/applications/cloudnative-pg/kustomization.yaml
+++ b/manifests/applications/cloudnative-pg/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - rules.yaml
-  - https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.5.0/manifest.yaml
+  - https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.7.0/manifest.yaml
 
 helmCharts:
   - name: cloudnative-pg


### PR DESCRIPTION
Update the manifest URL for the barman-cloud plugin to point to version 0.7.0.