### PR TITLE
Update walStorage size to 75Gi in database-cluster.yaml

### DIFF
--- a/manifests/applications/mastodon/overlays/toot.community/database-cluster.yaml
+++ b/manifests/applications/mastodon/overlays/toot.community/database-cluster.yaml
@@ -9,7 +9,7 @@ spec:
   storage:
     size: 550Gi
   walStorage:
-    size: 60Gi
+    size: 75Gi
         
   postgresql:
     parameters:


### PR DESCRIPTION
Adjust the walStorage size in the configuration to improve performance and accommodate increased data requirements.