### PR TITLE
Update memory limit for ingress-nginx controller to 4Gi

### DIFF
--- a/manifests/applications/ingress-nginx/helm-values.yaml
+++ b/manifests/applications/ingress-nginx/helm-values.yaml
@@ -84,4 +84,4 @@ controller:
       cpu: 256m
       memory: 750Mi # don't KRR
     limits:
-      memory: 1500Mi
+      memory: 4Gi


### PR DESCRIPTION
Increase the memory limit for the ingress-nginx controller.