### PR TITLE
Add failover delay and connection settings for PostgreSQL

### DIFF
--- a/manifests/applications/mastodon/base/database-cluster.yaml
+++ b/manifests/applications/mastodon/base/database-cluster.yaml
@@ -4,6 +4,8 @@ metadata:
   name: database
 spec:
   instances: 2
+  failoverDelay: 15 # don't failover immediately on network blips
+  
   # imageName: patch-me
   primaryUpdateStrategy: unsupervised
   enablePDB: true
@@ -26,6 +28,10 @@ spec:
 
   postgresql:
     parameters:
+      # connection settings
+      wal_receiver_timeout: 30s
+      wal_sender_timeout: 30s
+      
       # statistics
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: "all"


### PR DESCRIPTION
Introduce a failover delay to prevent immediate failover during network issues.