### PR TITLE
refactor(mastodon): restructure Helm chart values for consistency

### DIFF
--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mastodon
 description: A Mastodon Helm chart for Kubernetes
 type: application
-version: v1.0.0
+version: 1.0.0
 appVersion: v4.5.3

--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -3,3 +3,4 @@ name: mastodon
 description: A Mastodon Helm chart for Kubernetes
 type: application
 version: v1.0.0
+appVersion: v4.5.3

--- a/charts/mastodon/templates/configuration.yaml
+++ b/charts/mastodon/templates/configuration.yaml
@@ -45,8 +45,11 @@ data:
   {{- if .Values.mastodon.allowedPrivateAddresses }}
   ALLOWED_PRIVATE_ADDRESSES: {{ .Values.mastodon.allowedPrivateAddresses }}
   {{- end }}
-  {{- if .Values.translations.enabled }}
+  {{- if and .Values.translations.enabled .Values.translations.libretranslate.enabled }}
   LIBRE_TRANSLATE_ENDPOINT: {{ .Values.translations.libretranslate.endpoint }}
+  {{- end }}
+  {{- if and .Values.translations.enabled .Values.translations.deepl.enabled }}
+  DEEPL_PLAN: {{ .Values.translations.deepl.plan }}
   {{- end }}
   {{- if .Values.search.enabled }}
   ES_ENABLED: "true"
@@ -67,8 +70,8 @@ data:
   {{- if .Values.mastodon.trustedProxyIp }}
   TRUSTED_PROXY_IP: {{ .Values.mastodon.trustedProxyIp }}
   {{- end }}
-  IP_RETENTION_PERIOD: {{ .Values.mastodon.ipRetentionPeriod | quote }}
-  SESSION_RETENTION_PERIOD: {{ .Values.mastodon.sessionRetentionPeriod | quote }}
+  IP_RETENTION_PERIOD: {{ .Values.mastodon.ipRetentionPeriod | int64 | quote }}
+  SESSION_RETENTION_PERIOD: {{ .Values.mastodon.sessionRetentionPeriod | int64 | quote }}
   {{- if .Values.observability.metrics.enabled }}
   MASTODON_PROMETHEUS_EXPORTER_ENABLED: "true"
   MASTODON_PROMETHEUS_EXPORTER_WEB_DETAILED_METRICS: "{{ .Values.observability.metrics.web.detailed | default "false" }}"

--- a/charts/mastodon/templates/configuration.yaml
+++ b/charts/mastodon/templates/configuration.yaml
@@ -1,85 +1,87 @@
 apiVersion: v1
 data:
-  DB_HOST: {{ .Values.configuration.database.host }}
-  DB_NAME: {{ .Values.configuration.database.name }}
-  DB_POOL: {{ .Values.configuration.database.poolsize | quote }}
-  DB_PORT: {{ .Values.configuration.database.port | quote }}
-  DB_SSLMODE: {{ .Values.configuration.database.sslmode }}
-  {{- if .Values.configuration.databaseReplicas.enabled }}
-  REPLICA_DB_HOST: {{ .Values.configuration.databaseReplicas.host }}
-  REPLICA_DB_PORT: {{ .Values.configuration.databaseReplicas.port | quote }}
+  DB_HOST: {{ .Values.database.primary.host }}
+  DB_NAME: {{ .Values.database.primary.name }}
+  DB_POOL: {{ .Values.database.primary.poolSize | quote }}
+  DB_PORT: {{ .Values.database.primary.port | quote }}
+  DB_SSLMODE: {{ .Values.database.primary.sslMode }}
+  {{- if .Values.database.replica.enabled }}
+  REPLICA_DB_HOST: {{ .Values.database.replica.host }}
+  REPLICA_DB_PORT: {{ .Values.database.replica.port | quote }}
   {{- end }}
-  DEFAULT_LOCALE: {{ .Values.configuration.defaultLocale }}
-  LOCAL_DOMAIN: {{ .Values.configuration.localDomain }}
+  DEFAULT_LOCALE: {{ .Values.mastodon.defaultLocale }}
+  LOCAL_DOMAIN: {{ .Values.mastodon.localDomain }}
   MALLOC_ARENA_MAX: "2"
   NODE_ENV: production
   PREPARED_STATEMENTS: "false"
   RAILS_ENV: production
-  REDIS_HOST: {{ .Values.configuration.redis.host }}
-  REDIS_PORT: {{ .Values.configuration.redis.port | quote }}
-  REDIS_DB: {{ .Values.configuration.redis.database | default 0 | quote }}
-  S3_ALIAS_HOST: {{ .Values.configuration.s3.aliasHost }}
-  S3_BUCKET: {{ .Values.configuration.s3.bucket }}
+  REDIS_HOST: {{ .Values.redis.host }}
+  REDIS_PORT: {{ .Values.redis.port | quote }}
+  REDIS_DB: {{ .Values.redis.database | default 0 | quote }}
+  S3_ALIAS_HOST: {{ .Values.s3.aliasHost }}
+  S3_BUCKET: {{ .Values.s3.bucket }}
   S3_ENABLED: "true"
-  S3_ENDPOINT: {{ .Values.configuration.s3.endpoint }}
-  S3_HOSTNAME: {{ .Values.configuration.s3.hostname }}
-  S3_PROTOCOL: {{ .Values.configuration.s3.protocol }}
-  S3_REGION: {{ .Values.configuration.s3.region }}
-  S3_OPEN_TIMEOUT: {{ .Values.configuration.s3.timeouts.open | default 5 | quote }}
-  S3_READ_TIMEOUT: {{ .Values.configuration.s3.timeouts.read | default 5 | quote }}
-  S3_MULTIPART_THRESHOLD: {{ .Values.configuration.s3.multipartThreshold | default "10485760" | quote }}
-  SMTP_AUTH_METHOD: {{ .Values.configuration.smtp.authMethod }}
-  SMTP_CA_FILE: {{ .Values.configuration.smtp.caFile }}
-  SMTP_DELIVERY_METHOD: {{ .Values.configuration.smtp.deliveryMethod }}
-  SMTP_ENABLE_STARTTLS_AUTO: {{ .Values.configuration.smtp.enableStarttlsAuto | quote }}
-  SMTP_OPENSSL_VERIFY_MODE: {{ .Values.configuration.smtp.opensslVerifyMode }}
-  SMTP_PORT: {{ .Values.configuration.smtp.port | quote }}
-  SMTP_DOMAIN: {{ .Values.configuration.smtp.domain }}
-  SMTP_FROM_ADDRESS: {{ .Values.configuration.smtp.fromAddress }}
-  SMTP_SERVER: {{ .Values.configuration.smtp.smtpServer }}
+  S3_ENDPOINT: {{ .Values.s3.endpoint }}
+  S3_HOSTNAME: {{ .Values.s3.hostname }}
+  S3_PROTOCOL: {{ .Values.s3.protocol }}
+  S3_REGION: {{ .Values.s3.region }}
+  S3_OPEN_TIMEOUT: {{ .Values.s3.timeouts.open | default 5 | quote }}
+  S3_READ_TIMEOUT: {{ .Values.s3.timeouts.read | default 5 | quote }}
+  S3_MULTIPART_THRESHOLD: {{ .Values.s3.multipartThreshold | default "10485760" | quote }}
+  SMTP_AUTH_METHOD: {{ .Values.smtp.authMethod }}
+  SMTP_CA_FILE: {{ .Values.smtp.caFile }}
+  SMTP_DELIVERY_METHOD: {{ .Values.smtp.deliveryMethod }}
+  SMTP_ENABLE_STARTTLS_AUTO: {{ .Values.smtp.enableStarttlsAuto | quote }}
+  SMTP_OPENSSL_VERIFY_MODE: {{ .Values.smtp.opensslVerifyMode }}
+  SMTP_PORT: {{ .Values.smtp.port | quote }}
+  SMTP_DOMAIN: {{ .Values.smtp.domain }}
+  SMTP_FROM_ADDRESS: {{ .Values.smtp.fromAddress }}
+  SMTP_SERVER: {{ .Values.smtp.server }}
   SMTP_TLS: "true"
   STREAMING_CLUSTER_NUM: {{ .Values.streaming.clusterNum | quote }}
-  WEB_DOMAIN: {{ .Values.web.domain }}
+  WEB_DOMAIN: {{ .Values.mastodon.webDomain | default .Values.mastodon.localDomain }}
   WEB_CONCURRENCY: {{ .Values.web.concurrency | quote }}
   MAX_THREADS: {{ .Values.web.maxThreads | quote }}
-  ALLOWED_PRIVATE_ADDRESSES: {{ .Values.configuration.allowedPrivateAddresses }}
+  {{- if .Values.mastodon.allowedPrivateAddresses }}
+  ALLOWED_PRIVATE_ADDRESSES: {{ .Values.mastodon.allowedPrivateAddresses }}
+  {{- end }}
   {{- if .Values.translations.enabled }}
   LIBRE_TRANSLATE_ENDPOINT: {{ .Values.translations.libretranslate.endpoint }}
   {{- end }}
-  {{- if .Values.configuration.search.enabled }}
+  {{- if .Values.search.enabled }}
   ES_ENABLED: "true"
-  ES_HOST: {{ .Values.configuration.search.host }}
-  ES_PORT: {{ .Values.configuration.search.port | quote }}
-  ES_USER: {{ .Values.configuration.search.user }}
-  ES_PRESET: {{ .Values.configuration.search.preset | default "single_node_cluster" }}
+  ES_HOST: {{ .Values.search.host }}
+  ES_PORT: {{ .Values.search.port | quote }}
+  ES_USER: {{ .Values.search.user }}
+  ES_PRESET: {{ .Values.search.preset | default "single_node_cluster" }}
   {{- end }}
-  {{- if .Values.streaming.baseURL }}
-  STREAMING_API_BASE_URL: {{ .Values.streaming.baseURL }}
+  {{- if .Values.streaming.baseUrl }}
+  STREAMING_API_BASE_URL: {{ .Values.streaming.baseUrl }}
   {{- end }}
-  {{- if .Values.configuration.authorizedFetch }}
+  {{- if .Values.mastodon.authorizedFetch }}
   AUTHORIZED_FETCH: "true"
   {{- end }}
-  {{- if .Values.configuration.limitedFederationMode }}
+  {{- if .Values.mastodon.limitedFederationMode }}
   LIMITED_FEDERATION_MODE: "true"
   {{- end }}
-  {{- if .Values.configuration.trustedProxyIPs }}
-  TRUSTED_PROXY_IP: {{ .Values.configuration.trustedProxyIPs }}
+  {{- if .Values.mastodon.trustedProxyIp }}
+  TRUSTED_PROXY_IP: {{ .Values.mastodon.trustedProxyIp }}
   {{- end }}
-  IP_RETENTION_PERIOD: {{ .Values.configuration.ipRetentionPeriod | quote }}
-  SESSION_RETENTION_PERIOD: {{ .Values.configuration.sessionRetentionPeriod | quote }}
-  {{- if .Values.metrics.enabled }}
+  IP_RETENTION_PERIOD: {{ .Values.mastodon.ipRetentionPeriod | quote }}
+  SESSION_RETENTION_PERIOD: {{ .Values.mastodon.sessionRetentionPeriod | quote }}
+  {{- if .Values.observability.metrics.enabled }}
   MASTODON_PROMETHEUS_EXPORTER_ENABLED: "true"
-  MASTODON_PROMETHEUS_EXPORTER_WEB_DETAILED_METRICS: "{{ .Values.metrics.web.detailed | default "false" }}"
-  MASTODON_PROMETHEUS_EXPORTER_SIDEKIQ_DETAILED_METRICS: "{{ .Values.metrics.sidekiq.detailed | default "false" }}"
+  MASTODON_PROMETHEUS_EXPORTER_WEB_DETAILED_METRICS: "{{ .Values.observability.metrics.web.detailed | default "false" }}"
+  MASTODON_PROMETHEUS_EXPORTER_SIDEKIQ_DETAILED_METRICS: "{{ .Values.observability.metrics.sidekiq.detailed | default "false" }}"
   PROMETHEUS_EXPORTER_HOST: "127.0.0.1"
-  PROMETHEUS_EXPORTER_PORT: "{{ .Values.metrics.port | default "9394" }}"
+  PROMETHEUS_EXPORTER_PORT: "{{ .Values.observability.metrics.port | default "9394" }}"
   {{- end }}
-  {{- if .Values.configuration.otel.enabled }}
-  OTEL_SERVICE_NAME_PREFIX: {{ .Values.configuration.otel.namePrefix }}
-  OTEL_SERVICE_NAME_SEPARATOR: {{ .Values.configuration.otel.nameSeparator | default "/" }}
-  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.configuration.otel.exporterUri }}
+  {{- if .Values.observability.otel.enabled }}
+  OTEL_SERVICE_NAME_PREFIX: {{ .Values.observability.otel.namePrefix }}
+  OTEL_SERVICE_NAME_SEPARATOR: {{ .Values.observability.otel.nameSeparator | default "/" }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.observability.otel.exporterUri }}
   {{- end }}
-  {{- range $key, $val := .Values.configuration.extraConfiguration }}
+  {{- range $key, $val := .Values.mastodon.extraEnv }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
 kind: ConfigMap

--- a/charts/mastodon/templates/deployment-debug.yaml
+++ b/charts/mastodon/templates/deployment-debug.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.debug -}}
+{{- if .Values.debug.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,11 +17,14 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configuration.yaml") . | sha256sum }}
+        {{- with .Values.global.podDefaults.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: debug
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -33,36 +36,17 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.web.port | quote }}
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.configuration.database.credentials.usernameKey }}
-                  name: {{ .Values.configuration.database.credentials.secretName }}
-            - name: DB_PASS
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.configuration.database.credentials.passwordKey }}
-                  name: {{ .Values.configuration.database.credentials.secretName }}
-            {{- if .Values.configuration.search.enabled }}
-            - name: ES_PASS
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.configuration.search.password.secretKeyRef.key }}
-                  name: {{ .Values.configuration.search.password.secretKeyRef.name }}
-            {{- end }}
+            {{- include "mastodon.commonEnv" . | nindent 12 }}
           envFrom:
-            - configMapRef:
-                name: {{ include "mastodon.fullname" . }}-env
-            - secretRef:
-                name: {{ include "mastodon.fullname" . }}-secrets-env
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- include "mastodon.commonEnvFrom" . | nindent 12 }}
+          image: "{{ include "mastodon.imageRepository" (dict "component" .Values.web "global" .Values.global "default" "ghcr.io/mastodon/mastodon") }}:{{ include "mastodon.imageTag" (dict "component" .Values.web "global" .Values.global "Chart" .Chart) }}"
+          imagePullPolicy: {{ include "mastodon.imagePullPolicy" (dict "component" .Values.web "global" .Values.global) }}
           name: debug
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.podDefaults.securityContext | nindent 12 }}
       restartPolicy: Always
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.global.podDefaults.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "mastodon.serviceAccountName" . }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.global.podDefaults.terminationGracePeriodSeconds }}
 {{- end -}}

--- a/charts/mastodon/templates/deployment-sidekiq.yaml
+++ b/charts/mastodon/templates/deployment-sidekiq.yaml
@@ -14,13 +14,12 @@ spec:
     matchLabels:
       {{- include "mastodon.selectorLabels" $context | nindent 6 }}
       app.kubernetes.io/component: sidekiq-{{ .name }}
+  {{- with .strategy | default $context.Values.sidekiq.defaults.strategy }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
-  {{- if .replicaCount }}
-  replicas: {{ .replicaCount }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .replicas }}
+  replicas: {{ .replicas }}
   {{- end }}
   template:
     metadata:
@@ -29,10 +28,17 @@ spec:
         app.kubernetes.io/component: sidekiq-{{ .name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configuration.yaml") $context | sha256sum }}
+        {{- with $context.Values.global.podDefaults.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
-      {{- if $context.Values.sidekiq.nodeSelector }}
+      {{- with $context.Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $context.Values.sidekiq.nodeSelector }}
       nodeSelector:
-        {{- toYaml $context.Values.sidekiq.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with $context.Values.sidekiq.tolerations }}
       tolerations:
@@ -54,7 +60,7 @@ spec:
           env:
             - name: DB_POOL
               value: {{ .concurrency | quote }}
-            {{- if $context.Values.metrics.enabled }}
+            {{- if $context.Values.observability.metrics.enabled }}
             - name: MASTODON_PROMETHEUS_EXPORTER_ENABLED
               value: "true"
             - name: MASTODON_PROMETHEUS_EXPORTER_LOCAL
@@ -62,38 +68,28 @@ spec:
             - name: MASTODON_PROMETHEUS_EXPORTER_HOST
               value: "0.0.0.0"
             - name: MASTODON_PROMETHEUS_EXPORTER_PORT
-              value: "{{ $context.Values.metrics.port }}"
+              value: "{{ $context.Values.observability.metrics.port }}"
             {{- end }}
             {{- include "mastodon.commonEnv" $context | nindent 12 }}
-          image: "{{ $context.Values.image.repository }}:{{ $context.Values.image.tag | default $context.Chart.AppVersion }}"
-          imagePullPolicy: {{ $context.Values.image.pullPolicy }}
+          image: "{{ include "mastodon.imageRepository" (dict "component" $context.Values.web "global" $context.Values.global "default" "ghcr.io/mastodon/mastodon") }}:{{ include "mastodon.imageTag" (dict "component" $context.Values.web "global" $context.Values.global "Chart" $context.Chart) }}"
+          imagePullPolicy: {{ include "mastodon.imagePullPolicy" (dict "component" $context.Values.web "global" $context.Values.global) }}
           name: mastodon
           resources:
-            {{- toYaml .resources | nindent 12 }}
+            {{- toYaml (.resources | default $context.Values.sidekiq.defaults.resources) | nindent 12 }}
           securityContext:
-            {{- toYaml $context.Values.securityContext | nindent 12 }}
-          {{- if $context.Values.metrics.enabled }}
+            {{- toYaml $context.Values.global.podDefaults.securityContext | nindent 12 }}
+          {{- if $context.Values.observability.metrics.enabled }}
           ports:
             - name: prometheus
-              containerPort: {{ $context.Values.metrics.port }}
+              containerPort: {{ $context.Values.observability.metrics.port }}
           {{- end }}
       restartPolicy: Always
-      {{- with $context.Values.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- toYaml $context.Values.global.podDefaults.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "mastodon.serviceAccountName" $context }}
-      terminationGracePeriodSeconds: {{ $context.Values.terminationGracePeriodSeconds }}
-      {{- if $context.Values.sidekiq.affinity.enabled }}
+      terminationGracePeriodSeconds: {{ $context.Values.global.podDefaults.terminationGracePeriodSeconds }}
+      {{- with $context.Values.sidekiq.affinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    {{- include "mastodon.selectorLabels" $context | nindent 20 }}
-                    app.kubernetes.io/component: sidekiq-{{ .name }}
-                topologyKey: {{ $context.Values.sidekiq.affinity.topologyKey }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/mastodon/templates/deployment-streaming.yaml
+++ b/charts/mastodon/templates/deployment-streaming.yaml
@@ -5,13 +5,13 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
     app: {{ include "mastodon.fullname" . }}-streaming
     version: {{ .Chart.AppVersion | quote }}
-  {{- if .Values.streaming.annotations }}
-    annotations:
-      {{- toYaml .Values.streaming.annotations | nindent 4 }}
+  {{- with .Values.streaming.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "mastodon.fullname" . }}-streaming
 spec:
-  replicas: {{ .Values.streaming.replicaCount | default 3 }}
+  replicas: {{ .Values.streaming.replicas }}
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}
@@ -25,36 +25,41 @@ spec:
         app.kubernetes.io/component: streaming
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configuration.yaml") . | sha256sum }}
+        {{- with .Values.global.podDefaults.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - command:
           - node
           - ./streaming
           env:
-            {{- if .Values.configuration.databaseReplicas.enabled }}
+            {{- if .Values.database.replica.enabled }}
             - name: DB_HOST
-              value: {{ .Values.configuration.databaseReplicas.host }}
+              value: {{ .Values.database.replica.host }}
             {{- end }}
-            {{- if .Values.streaming.redis }}
-            {{- if .Values.streaming.redis.url }}
+            {{- if .Values.redis.url }}
             - name: REDIS_URL
-              value: {{ .Values.streaming.redis.url }}
+              value: {{ .Values.redis.url }}
             - name: REDIS_HOST
               value: empty
             - name: REDIS_PORT
               value: empty
             {{- end }}
-            {{- end }}
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.configuration.database.credentials.usernameKey }}
-                  name: {{ .Values.configuration.database.credentials.secretName }}
+                  key: {{ .Values.database.credentials.usernameKey }}
+                  name: {{ .Values.database.credentials.secretName }}
             - name: DB_PASS
               valueFrom:
                 secretKeyRef:
-                  key: {{ .Values.configuration.database.credentials.passwordKey }}
-                  name: {{ .Values.configuration.database.credentials.secretName }}
+                  key: {{ .Values.database.credentials.passwordKey }}
+                  name: {{ .Values.database.credentials.secretName }}
             - name: PORT
               value: {{ .Values.streaming.port | quote }}
             - name: DB_SSLMODE
@@ -80,13 +85,21 @@ spec:
           resources:
             {{- toYaml .Values.streaming.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.podDefaults.securityContext | nindent 12 }}
       restartPolicy: Always
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.global.podDefaults.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "mastodon.serviceAccountName" . }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.global.podDefaults.terminationGracePeriodSeconds }}
       {{- with .Values.streaming.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.streaming.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.streaming.tolerations }}
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mastodon/templates/deployment-web.yaml
+++ b/charts/mastodon/templates/deployment-web.yaml
@@ -5,13 +5,13 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
     app: {{ include "mastodon.fullname" . }}-web
     version: {{ .Chart.AppVersion | quote }}
-  {{- if .Values.web.annotations }}
+  {{- with .Values.web.annotations }}
   annotations:
-    {{- toYaml .Values.web.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   name: {{ include "mastodon.fullname" . }}-web
 spec:
-  replicas: {{ .Values.web.replicaCount | default 2 }}
+  replicas: {{ .Values.web.replicas }}
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}
@@ -22,14 +22,14 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configuration.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}
+        {{- with .Values.global.podDefaults.annotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: web
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -46,8 +46,8 @@ spec:
             - name: PORT
               value: {{ .Values.web.port | quote }}
             {{- include "mastodon.commonEnv" . | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ include "mastodon.imageRepository" (dict "component" .Values.web "global" .Values.global "default" "ghcr.io/mastodon/mastodon") }}:{{ include "mastodon.imageTag" (dict "component" .Values.web "global" .Values.global "Chart" .Chart) }}"
+          imagePullPolicy: {{ include "mastodon.imagePullPolicy" (dict "component" .Values.web "global" .Values.global) }}
           name: web
           ports:
             - containerPort: {{ .Values.web.port }}
@@ -64,30 +64,38 @@ spec:
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-        {{- if .Values.metrics.enabled }}
+            {{- toYaml .Values.global.podDefaults.securityContext | nindent 12 }}
+        {{- if .Values.observability.metrics.enabled }}
         - name: prometheus-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "mastodon.imageRepository" (dict "component" .Values.web "global" .Values.global "default" "ghcr.io/mastodon/mastodon") }}:{{ include "mastodon.imageTag" (dict "component" .Values.web "global" .Values.global "Chart" .Chart) }}"
           command:
             - ./bin/prometheus_exporter
           args:
             - "--bind"
             - "0.0.0.0"
             - "--port"
-            - "{{ .Values.metrics.port }}"
-          resources: {{ toYaml .Values.metrics.web.exporter.resources | nindent 12 }}
+            - "{{ .Values.observability.metrics.port }}"
+          resources: {{ toYaml .Values.observability.metrics.web.exporter.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.global.podDefaults.securityContext | nindent 12 }}
           ports:
             - name: prometheus
-              containerPort: {{ .Values.metrics.port }}
+              containerPort: {{ .Values.observability.metrics.port }}
         {{- end }}
       restartPolicy: Always
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.global.podDefaults.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "mastodon.serviceAccountName" . }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.global.podDefaults.terminationGracePeriodSeconds }}
       {{- with .Values.web.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.tolerations }}
+      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mastodon/templates/deployment-web.yaml
+++ b/charts/mastodon/templates/deployment-web.yaml
@@ -53,10 +53,14 @@ spec:
             - containerPort: {{ .Values.web.port }}
               name: http
               protocol: TCP
+          {{- with .Values.web.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.web.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.startupProbe }}
           startupProbe:
-            {{- toYaml .Values.web.startupProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.web.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -75,7 +79,10 @@ spec:
             - "0.0.0.0"
             - "--port"
             - "{{ .Values.observability.metrics.port }}"
-          resources: {{ toYaml .Values.observability.metrics.web.exporter.resources | nindent 12 }}
+          {{- with .Values.observability.metrics.web.exporter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.global.podDefaults.securityContext | nindent 12 }}
           ports:

--- a/charts/mastodon/templates/httproute-web.yaml
+++ b/charts/mastodon/templates/httproute-web.yaml
@@ -23,6 +23,6 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: {{ ternary .Values.ingress.web.serviceNameOverride (printf "%s-web" $fullName) (ne .Values.ingress.web.serviceNameOverride nil) }}
-          port: {{ ternary .Values.ingress.web.servicePortOverride .Values.web.port (ne .Values.ingress.web.servicePortOverride nil) }}
+        - name: {{ ternary .Values.ingress.web.serviceOverride.name (printf "%s-web" $fullName) (ne .Values.ingress.web.serviceOverride.name nil) }}
+          port: {{ ternary .Values.ingress.web.serviceOverride.port .Values.web.port (ne .Values.ingress.web.serviceOverride.port nil) }}
 {{- end }}

--- a/charts/mastodon/templates/ingress-streaming.yaml
+++ b/charts/mastodon/templates/ingress-streaming.yaml
@@ -4,9 +4,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-    {{- if .Values.ingress.web.annotations }}
-    {{- toYaml .Values.ingress.web.annotations | nindent 4 }}
+    {{- with .Values.ingress.streaming.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}

--- a/charts/mastodon/templates/ingress-web-www-redirect.yaml
+++ b/charts/mastodon/templates/ingress-web-www-redirect.yaml
@@ -4,8 +4,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- if .Values.ingress.web.annotations }}
-    {{- toYaml .Values.ingress.web.annotations | nindent 4 }}
+    {{- with .Values.ingress.web.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
     nginx.ingress.kubernetes.io/permanent-redirect: https://{{ .Values.ingress.web.host }}
   labels:
@@ -19,14 +19,14 @@ spec:
         paths:
           - backend:
               service:
-                {{- if .Values.ingress.web.serviceNameOverride }}
-                name: {{ .Values.ingress.web.serviceNameOverride }}
+                {{- if .Values.ingress.web.serviceOverride.name }}
+                name: {{ .Values.ingress.web.serviceOverride.name }}
                 {{- else }}
                 name: {{ include "mastodon.fullname" . }}-web
                 {{- end }}
                 port:
-                  {{- if .Values.ingress.web.servicePortOverride }}
-                  number: {{ .Values.ingress.web.servicePortOverride }}
+                  {{- if .Values.ingress.web.serviceOverride.port }}
+                  number: {{ .Values.ingress.web.serviceOverride.port }}
                   {{- else }}
                   number: {{ .Values.web.port }}
                   {{- end }}

--- a/charts/mastodon/templates/ingress-web.yaml
+++ b/charts/mastodon/templates/ingress-web.yaml
@@ -6,16 +6,16 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.web.maxBodySize }}
     nginx.ingress.kubernetes.io/client-body-buffer-size: {{ .Values.ingress.web.maxBodySize }}
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: {{ .Values.ingress.web.upstreamProxyTimeout | quote }}
-    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.ingress.web.upstreamProxyTimeout | quote }}
-    nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.ingress.web.upstreamProxyTimeout | quote }}
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: {{ .Values.ingress.web.proxyTimeout | quote }}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.ingress.web.proxyTimeout | quote }}
+    nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.ingress.web.proxyTimeout | quote }}
     {{- if .Values.ingress.web.verifyClient.enabled }}
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ .Values.ingress.web.verifyClient.secretName }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
     nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "false"
     {{- end }}
-    {{- if .Values.ingress.web.annotations }}
-    {{- toYaml .Values.ingress.web.annotations | nindent 4 }}
+    {{- with .Values.ingress.web.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
     {{- include "mastodon.labels" . | nindent 4 }}
@@ -28,14 +28,14 @@ spec:
         paths:
           - backend:
               service:
-                {{- if .Values.ingress.web.serviceNameOverride }}
-                name: {{ .Values.ingress.web.serviceNameOverride }}
+                {{- if .Values.ingress.web.serviceOverride.name }}
+                name: {{ .Values.ingress.web.serviceOverride.name }}
                 {{- else }}
                 name: {{ include "mastodon.fullname" . }}-web
                 {{- end }}
                 port:
-                  {{- if .Values.ingress.web.servicePortOverride }}
-                  number: {{ .Values.ingress.web.servicePortOverride }}
+                  {{- if .Values.ingress.web.serviceOverride.port }}
+                  number: {{ .Values.ingress.web.serviceOverride.port }}
                   {{- else }}
                   number: {{ .Values.web.port }}
                   {{- end }}

--- a/charts/mastodon/templates/job-db-migrate-post.yaml
+++ b/charts/mastodon/templates/job-db-migrate-post.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.configuration.database.runDatabaseMigrations | default false }}
+{{ if .Values.database.migrations.runOnUpgrade | default false }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/mastodon/templates/job-db-migrate-pre.yaml
+++ b/charts/mastodon/templates/job-db-migrate-pre.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.configuration.database.runDatabaseMigrations | default false }}
+{{ if .Values.database.migrations.runOnUpgrade | default false }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/mastodon/templates/servicemonitor-sidekiq.yaml
+++ b/charts/mastodon/templates/servicemonitor-sidekiq.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.metrics.podMonitor.enabled }}
+{{ if .Values.observability.metrics.podMonitor.enabled }}
 {{- $context := . }}
 {{- range .Values.sidekiq.workers }}
 ---
@@ -15,9 +15,9 @@ spec:
       app.kubernetes.io/component: sidekiq-{{ .name }}
   podMetricsEndpoints:
     - port: prometheus
-      interval: {{ $context.Values.metrics.podMonitor.interval }}
-      scrapeTimeout: {{ $context.Values.metrics.podMonitor.scrapeTimeout }}
-      path: {{ $context.Values.metrics.podMonitor.path }}
-      scheme: {{ $context.Values.metrics.podMonitor.scheme }}
+      interval: {{ $context.Values.observability.metrics.podMonitor.interval }}
+      scrapeTimeout: {{ $context.Values.observability.metrics.podMonitor.scrapeTimeout }}
+      path: {{ $context.Values.observability.metrics.podMonitor.path }}
+      scheme: {{ $context.Values.observability.metrics.podMonitor.scheme }}
 {{ end }}
 {{ end }}

--- a/charts/mastodon/templates/servicemonitor-sidekiq.yaml
+++ b/charts/mastodon/templates/servicemonitor-sidekiq.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.observability.metrics.podMonitor.enabled }}
+{{ if and .Values.observability.metrics.enabled .Values.observability.metrics.podMonitor.enabled }}
 {{- $context := . }}
 {{- range .Values.sidekiq.workers }}
 ---

--- a/charts/mastodon/templates/servicemonitor-streaming.yaml
+++ b/charts/mastodon/templates/servicemonitor-streaming.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.observability.metrics.podMonitor.enabled }}
+{{ if and .Values.observability.metrics.enabled .Values.observability.metrics.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/mastodon/templates/servicemonitor-streaming.yaml
+++ b/charts/mastodon/templates/servicemonitor-streaming.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.streaming.podMonitor.enabled }}
+{{ if .Values.observability.metrics.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -11,9 +11,9 @@ spec:
     matchLabels:
       app.kubernetes.io/component: streaming
   podMetricsEndpoints:
-    - port: {{ .Values.streaming.podMonitor.port }}
-      interval: {{ .Values.streaming.podMonitor.interval }}
-      scrapeTimeout: {{ .Values.streaming.podMonitor.scrapeTimeout }}
-      path: {{ .Values.streaming.podMonitor.path }}
-      scheme: {{ .Values.streaming.podMonitor.scheme }}
+    - port: {{ .Values.streaming.podMonitor.port | default "streaming" }}
+      interval: {{ .Values.observability.metrics.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.observability.metrics.podMonitor.scrapeTimeout }}
+      path: {{ .Values.observability.metrics.podMonitor.path }}
+      scheme: {{ .Values.observability.metrics.podMonitor.scheme }}
 {{ end }}

--- a/charts/mastodon/templates/servicemonitor-web.yaml
+++ b/charts/mastodon/templates/servicemonitor-web.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.observability.metrics.podMonitor.enabled }}
+{{ if and .Values.observability.metrics.enabled .Values.observability.metrics.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/mastodon/templates/servicemonitor-web.yaml
+++ b/charts/mastodon/templates/servicemonitor-web.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.metrics.podMonitor.enabled }}
+{{ if .Values.observability.metrics.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -12,8 +12,8 @@ spec:
       app.kubernetes.io/component: web
   podMetricsEndpoints:
     - port: prometheus
-      interval: {{ .Values.metrics.podMonitor.interval }}
-      scrapeTimeout: {{ .Values.metrics.podMonitor.scrapeTimeout }}
-      path: {{ .Values.metrics.podMonitor.path }}
-      scheme: {{ .Values.metrics.podMonitor.scheme }}
+      interval: {{ .Values.observability.metrics.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.observability.metrics.podMonitor.scrapeTimeout }}
+      path: {{ .Values.observability.metrics.podMonitor.path }}
+      scheme: {{ .Values.observability.metrics.podMonitor.scheme }}
 {{ end }}

--- a/charts/mastodon/values.schema.json
+++ b/charts/mastodon/values.schema.json
@@ -1,0 +1,380 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/toot-community/platform/charts/mastodon/values.schema.json",
+  "title": "Mastodon Helm Chart Values",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "description": "Global settings inherited by all components",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": "string" }
+          }
+        },
+        "imagePullSecrets": { "type": "array" },
+        "podDefaults": {
+          "type": "object",
+          "properties": {
+            "annotations": { "type": "object" },
+            "securityContext": { "type": "object" },
+            "podSecurityContext": { "type": "object" },
+            "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "mastodon": {
+      "type": "object",
+      "description": "Mastodon application configuration",
+      "properties": {
+        "localDomain": { "type": "string", "description": "Primary domain for the Mastodon instance" },
+        "webDomain": { "type": "string" },
+        "defaultLocale": { "type": "string" },
+        "authorizedFetch": { "type": "boolean" },
+        "limitedFederationMode": { "type": "boolean" },
+        "ipRetentionPeriod": { "type": "integer", "minimum": 0 },
+        "sessionRetentionPeriod": { "type": "integer", "minimum": 0 },
+        "trustedProxyIp": { "type": "string" },
+        "allowedPrivateAddresses": { "type": "string" },
+        "extraEnv": { "type": "object" }
+      },
+      "required": ["localDomain"]
+    },
+    "database": {
+      "type": "object",
+      "description": "Database configuration",
+      "properties": {
+        "primary": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer" },
+            "name": { "type": "string" },
+            "poolSize": { "type": "integer", "minimum": 1 },
+            "sslMode": { "type": "string" }
+          },
+          "required": ["host", "port", "name"]
+        },
+        "replica": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "host": { "type": "string" },
+            "port": { "type": "integer" }
+          }
+        },
+        "migrations": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer" },
+            "name": { "type": "string" },
+            "runOnUpgrade": { "type": "boolean" }
+          }
+        },
+        "credentials": {
+          "type": "object",
+          "properties": {
+            "secretName": { "type": "string" },
+            "usernameKey": { "type": "string" },
+            "passwordKey": { "type": "string" }
+          },
+          "required": ["secretName", "usernameKey", "passwordKey"]
+        }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "host": { "type": "string" },
+        "port": { "type": "integer" },
+        "database": { "type": "integer" },
+        "url": { "type": "string", "description": "Full Redis URL (takes precedence over host/port)" }
+      }
+    },
+    "s3": {
+      "type": "object",
+      "description": "Object storage (S3) configuration",
+      "properties": {
+        "bucket": { "type": "string" },
+        "region": { "type": "string" },
+        "endpoint": { "type": "string" },
+        "hostname": { "type": "string" },
+        "protocol": { "type": "string", "enum": ["http", "https"] },
+        "aliasHost": { "type": "string" },
+        "multipartThreshold": { "type": "string" },
+        "timeouts": {
+          "type": "object",
+          "properties": {
+            "open": { "type": "integer" },
+            "read": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "smtp": {
+      "type": "object",
+      "description": "Email (SMTP) configuration",
+      "properties": {
+        "server": { "type": "string" },
+        "port": { "type": "integer" },
+        "domain": { "type": "string" },
+        "fromAddress": { "type": "string" },
+        "authMethod": { "type": "string" },
+        "deliveryMethod": { "type": "string" },
+        "enableStarttlsAuto": { "type": "boolean" },
+        "opensslVerifyMode": { "type": "string" },
+        "caFile": { "type": "string" },
+        "tls": { "type": "boolean" }
+      }
+    },
+    "search": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "host": { "type": "string" },
+        "port": { "type": "integer" },
+        "preset": { "type": "string" },
+        "password": { "type": "object" }
+      }
+    },
+    "translations": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "libretranslate": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "endpoint": { "type": "string" }
+          }
+        },
+        "deepl": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "plan": { "type": "string" }
+          }
+        }
+      }
+    },
+    "observability": {
+      "type": "object",
+      "properties": {
+        "otel": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namePrefix": { "type": "string" },
+            "nameSeparator": { "type": "string" },
+            "exporterUri": { "type": "string" }
+          }
+        },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "port": { "type": "integer" },
+            "web": { "type": "object" },
+            "sidekiq": { "type": "object" },
+            "podMonitor": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "interval": { "type": "string" },
+                "scrapeTimeout": { "type": "string" },
+                "path": { "type": "string" },
+                "scheme": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "web": {
+      "type": "object",
+      "description": "Web component configuration",
+      "properties": {
+        "replicas": { "type": "integer", "minimum": 1 },
+        "port": { "type": "integer" },
+        "concurrency": { "type": "integer" },
+        "maxThreads": { "type": "integer" },
+        "resources": { "$ref": "#/$defs/resources" },
+        "strategy": { "$ref": "#/$defs/strategy" },
+        "podDisruptionBudget": { "$ref": "#/$defs/podDisruptionBudget" },
+        "affinity": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "startupProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "livenessProbe": { "type": "object" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "streaming": {
+      "type": "object",
+      "description": "Streaming component configuration",
+      "properties": {
+        "replicas": { "type": "integer", "minimum": 1 },
+        "port": { "type": "integer" },
+        "clusterNum": { "type": "integer" },
+        "baseUrl": { "type": "string" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "pullPolicy": { "type": "string" },
+            "tag": { "type": "string" }
+          }
+        },
+        "databaseSslMode": { "type": "string" },
+        "resources": { "$ref": "#/$defs/resources" },
+        "strategy": { "$ref": "#/$defs/strategy" },
+        "podDisruptionBudget": { "$ref": "#/$defs/podDisruptionBudget" },
+        "affinity": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" }
+      }
+    },
+    "sidekiq": {
+      "type": "object",
+      "description": "Sidekiq background job processor configuration",
+      "properties": {
+        "defaults": {
+          "type": "object",
+          "properties": {
+            "resources": { "$ref": "#/$defs/resources" },
+            "strategy": { "$ref": "#/$defs/strategy" }
+          }
+        },
+        "podDisruptionBudget": { "$ref": "#/$defs/podDisruptionBudget" },
+        "affinity": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "workers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "replicas": { "type": "integer", "minimum": 1 },
+              "concurrency": { "type": "integer", "minimum": 1 },
+              "queues": { "type": "array", "items": { "type": "string" } },
+              "resources": { "$ref": "#/$defs/resources" }
+            },
+            "required": ["name", "queues"]
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "web": { "$ref": "#/$defs/ingressConfig" },
+        "streaming": { "$ref": "#/$defs/ingressConfig" }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parentRefs": { "type": "array" },
+        "web": { "type": "object" },
+        "streaming": { "type": "object" }
+      }
+    },
+    "jobs": {
+      "type": "object",
+      "properties": {
+        "defaults": { "type": "object" },
+        "annotations": { "type": "object" },
+        "cleanupMedia": { "$ref": "#/$defs/cronJob" },
+        "cleanupMediaProfiles": { "$ref": "#/$defs/cronJob" },
+        "removePreviewCards": { "$ref": "#/$defs/cronJob" },
+        "statusesRemove": { "$ref": "#/$defs/cronJob" },
+        "accountsPrune": { "$ref": "#/$defs/cronJob" }
+      }
+    },
+    "debug": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  },
+  "$defs": {
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    },
+    "strategy": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["RollingUpdate", "Recreate"] },
+        "rollingUpdate": {
+          "type": "object",
+          "properties": {
+            "maxSurge": { "type": ["string", "integer"] },
+            "maxUnavailable": { "type": ["string", "integer"] }
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["string", "integer"] },
+        "maxUnavailable": { "type": ["string", "integer"] }
+      }
+    },
+    "ingressConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressClassName": { "type": "string" },
+        "host": { "type": "string" },
+        "annotations": { "type": "object" },
+        "tls": { "type": "array" }
+      }
+    },
+    "cronJob": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "schedule": { "type": "string" },
+        "resources": { "$ref": "#/$defs/resources" }
+      }
+    }
+  }
+}

--- a/charts/mastodon/values.yaml
+++ b/charts/mastodon/values.yaml
@@ -58,8 +58,8 @@ mastodon:
   limitedFederationMode: false
 
   # Privacy settings
-  ipRetentionPeriod: "31556952"      # 1 year in seconds
-  sessionRetentionPeriod: "31556952"  # 1 year in seconds
+  ipRetentionPeriod: 31556952      # 1 year in seconds
+  sessionRetentionPeriod: 31556952  # 1 year in seconds
 
   # Network settings
   trustedProxyIp: "10.244.0.0/16"
@@ -112,12 +112,12 @@ redis:
 # OBJECT STORAGE (S3)
 # =============================================================================
 s3:
-  bucket: static-toot-community
-  region: region
-  endpoint: https://endpoint.of.s3
-  hostname: hostname.of.s3
+  bucket: ""  # REQUIRED: S3 bucket name
+  region: ""  # REQUIRED: S3 region
+  endpoint: ""  # REQUIRED: S3 endpoint URL
+  hostname: ""  # REQUIRED: S3 hostname
   protocol: https
-  aliasHost: static.toot.community
+  aliasHost: ""  # REQUIRED: CDN/alias hostname for static assets
   multipartThreshold: "1024000000"  # 1GB (essentially disabling multipart uploads)
   timeouts:
     open: 10
@@ -127,10 +127,10 @@ s3:
 # EMAIL (SMTP)
 # =============================================================================
 smtp:
-  server: smtp.server
+  server: ""  # REQUIRED: SMTP server hostname
   port: 465
-  domain: toot.community
-  fromAddress: "toot.community Notifications <notifications@toot.community>"
+  domain: ""  # REQUIRED: Domain for SMTP HELO
+  fromAddress: ""  # REQUIRED: From address for outgoing emails
   authMethod: plain
   deliveryMethod: smtp
   enableStarttlsAuto: true
@@ -158,9 +158,11 @@ search:
 translations:
   enabled: true
   libretranslate:
+    enabled: true
     endpoint: https://translate.mstdn.social/
-  # deepl:
-  #   plan: free
+  deepl:
+    enabled: false
+    plan: free
 
 # =============================================================================
 # OBSERVABILITY
@@ -283,7 +285,7 @@ streaming:
   clusterNum: 1
 
   # Base URL for WebSocket connections
-  baseUrl: wss://streaming.toot.community
+  baseUrl: ""  # REQUIRED: e.g., wss://streaming.example.com
 
   # Streaming has its own image (Node.js)
   image:
@@ -430,7 +432,7 @@ ingress:
   web:
     enabled: false
     ingressClassName: nginx
-    host: toot.community
+    host: ""  # REQUIRED when enabled: your domain
 
     # Service routing override (for cache layers like Varnish)
     serviceOverride:
@@ -444,7 +446,7 @@ ingress:
     # Client certificate verification
     verifyClient:
       enabled: false
-      secretName: tootcommunity/tootcommunity-ca-secret
+      secretName: ""
 
     # WWW to non-WWW redirect
     wwwRedirect:
@@ -455,25 +457,19 @@ ingress:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
-    tls:
-      - hosts:
-          - toot.community
-        secretName: toot.community-tls
+    tls: []  # Configure TLS when enabled
 
   streaming:
     enabled: false
     ingressClassName: nginx
-    host: streaming.toot.community
+    host: ""  # REQUIRED when enabled: streaming domain
 
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
-    tls:
-      - hosts:
-          - streaming.toot.community
-        secretName: streaming.toot.community-tls
+    tls: []  # Configure TLS when enabled
 
 # =============================================================================
 # GATEWAY API

--- a/charts/mastodon/values.yaml
+++ b/charts/mastodon/values.yaml
@@ -1,147 +1,237 @@
-image:
-  repository: ghcr.io/mastodon/mastodon
-  pullPolicy: IfNotPresent
+# =============================================================================
+# GLOBAL SETTINGS
+# =============================================================================
+global:
+  # Default image for all Mastodon components (web, sidekiq, jobs)
+  image:
+    repository: ghcr.io/mastodon/mastodon
+    pullPolicy: IfNotPresent
+    tag: ""  # Defaults to Chart.AppVersion if empty
 
-imagePullSecrets: []
+  imagePullSecrets: []
+
+  # Default pod settings inherited by all components
+  podDefaults:
+    annotations: {}
+
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      runAsNonRoot: true
+      runAsUser: 991
+      seccompProfile:
+        type: RuntimeDefault
+
+    podSecurityContext:
+      fsGroup: 991
+      runAsGroup: 991
+      runAsUser: 991
+
+    terminationGracePeriodSeconds: 30
+
+# =============================================================================
+# CHART METADATA
+# =============================================================================
 nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
   create: true
+  name: ""
   annotations: {}
 
-podAnnotations: {}
+# =============================================================================
+# APPLICATION CONFIGURATION
+# =============================================================================
+mastodon:
+  # Instance domain settings
+  localDomain: example.com
+  webDomain: ""  # Defaults to localDomain if empty
 
-podSecurityContext:
-  fsGroup: 991
-  runAsGroup: 991
-  runAsUser: 991
+  # Localization
+  defaultLocale: en
 
-terminationGracePeriodSeconds: 30
+  # Federation settings
+  authorizedFetch: false
+  limitedFederationMode: false
 
-securityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-      - ALL
-  runAsNonRoot: true
-  runAsUser: 991
-  seccompProfile:
-    type: RuntimeDefault
+  # Privacy settings
+  ipRetentionPeriod: "31556952"      # 1 year in seconds
+  sessionRetentionPeriod: "31556952"  # 1 year in seconds
 
-configuration:
-  database:
+  # Network settings
+  trustedProxyIp: "10.244.0.0/16"
+  allowedPrivateAddresses: ""  # e.g., 10.0.8.0/21 for ES service subnet
+
+  # Extra environment variables (key-value pairs)
+  extraEnv: {}
+
+# =============================================================================
+# DATABASE CONFIGURATION
+# =============================================================================
+database:
+  # Primary database connection (through pooler)
+  primary:
     host: database-pooler-rw
-    name: app
-    poolsize: 25
     port: 5432
-    dbMigrations: # to circumvent pgpooler
-      port: 5432
-      name: app
-      host: database-rw
-    sslmode: require
-    runDatabaseMigrations: true
-    credentials:
-      usernameKey: username
-      passwordKey: password
-      secretName: database-app
-  databaseReplicas:
+    name: app
+    poolSize: 25
+    sslMode: require
+
+  # Read replica for read-heavy workloads (used by streaming if enabled)
+  replica:
     enabled: false
     host: database-pooler-ro
     port: 5432
-  defaultLocale: en
-  localDomain: example.com
-  allowedPrivateAddresses: 10.0.8.0/21 # service subnet to connect to ES
-  redis:
-    host: redis-ha-haproxy
-    port: 6379
-    database: 0
-  s3:
-    aliasHost: static.toot.community
-    bucket: static-toot-community
-    endpoint: https://endpoint.of.s3
-    hostname: hostname.of.s3
-    region: region
-    protocol: https
-    multipartThreshold: "1024000000" # 1GB (essentially disabling multipart uploads)
-    timeouts:
-      open: 10
-      read: 10
-  smtp:
-    authMethod: plain
-    caFile: /etc/ssl/certs/ca-certificates.crt
-    deliveryMethod: smtp
-    enableStarttlsAuto: true
-    opensslVerifyMode: peer
-    port: 465
-    domain: toot.community
-    fromAddress: toot.community Notifications <notifications@toot.community>
-    smtpServer: smtp.server
-  search:
-    enabled: false
-    host: elasticsearch-es-http
-    port: 9200
-    scheme: http
-    preset: single_node_cluster # https://github.com/mastodon/documentation/pull/1279/files
-    user: elastic
-    password:
-      secretKeyRef:
-        name: elasticsearch-es-elastic-user
-        key: elastic
-  ipRetentionPeriod: "31556952" # 1 year
-  sessionRetentionPeriod: "31556952" # 1 year
-  trustedProxyIPs: "10.244.0.0/16" # VPC POD CIDR
+
+  # Direct connection for migrations (bypasses pgbouncer)
+  migrations:
+    host: database-rw
+    port: 5432
+    name: app
+    runOnUpgrade: true
+
+  # Credentials from Kubernetes secret
+  credentials:
+    secretName: database-app
+    usernameKey: username
+    passwordKey: password
+
+# =============================================================================
+# REDIS CONFIGURATION
+# =============================================================================
+redis:
+  host: redis-ha-haproxy
+  port: 6379
+  database: 0
+  url: ""  # Full URL format (takes precedence if set, used by streaming)
+
+# =============================================================================
+# OBJECT STORAGE (S3)
+# =============================================================================
+s3:
+  bucket: static-toot-community
+  region: region
+  endpoint: https://endpoint.of.s3
+  hostname: hostname.of.s3
+  protocol: https
+  aliasHost: static.toot.community
+  multipartThreshold: "1024000000"  # 1GB (essentially disabling multipart uploads)
+  timeouts:
+    open: 10
+    read: 10
+
+# =============================================================================
+# EMAIL (SMTP)
+# =============================================================================
+smtp:
+  server: smtp.server
+  port: 465
+  domain: toot.community
+  fromAddress: "toot.community Notifications <notifications@toot.community>"
+  authMethod: plain
+  deliveryMethod: smtp
+  enableStarttlsAuto: true
+  opensslVerifyMode: peer
+  caFile: /etc/ssl/certs/ca-certificates.crt
+
+# =============================================================================
+# SEARCH (ELASTICSEARCH)
+# =============================================================================
+search:
+  enabled: false
+  host: elasticsearch-es-http
+  port: 9200
+  scheme: http
+  user: elastic
+  preset: single_node_cluster  # https://github.com/mastodon/documentation/pull/1279/files
+  password:
+    secretKeyRef:
+      name: elasticsearch-es-elastic-user
+      key: elastic
+
+# =============================================================================
+# TRANSLATIONS
+# =============================================================================
+translations:
+  enabled: true
+  libretranslate:
+    endpoint: https://translate.mstdn.social/
+  # deepl:
+  #   plan: free
+
+# =============================================================================
+# OBSERVABILITY
+# =============================================================================
+observability:
+  # OpenTelemetry tracing
   otel:
     enabled: false
     namePrefix: mastodon
-    nameSeparator: /
+    nameSeparator: "/"
     exporterUri: http://otel-collector:4317
-  extraConfiguration: {}
 
+  # Prometheus metrics
+  metrics:
+    enabled: true
+    port: 9394
+
+    # Web component metrics
+    web:
+      detailed: true
+      exporter:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 180Mi
+          limits:
+            memory: 250Mi
+
+    # Sidekiq metrics
+    sidekiq:
+      detailed: true
+
+    # PodMonitor configuration (shared across components)
+    podMonitor:
+      enabled: true
+      interval: 30s
+      scrapeTimeout: 10s
+      path: /metrics
+      scheme: http
+
+# =============================================================================
+# COMPONENT: WEB
+# =============================================================================
 web:
-  domain: toot.community
+  replicas: 2
+  port: 3000
+
+  # Puma configuration
   concurrency: 2
   maxThreads: 5
-  port: 3000
+
+  # Image override (inherits from global.image if not set)
+  image: {}
+
   resources:
     requests:
       cpu: 275m
       memory: 1045Mi
     limits:
       memory: 1045Mi
-  startupProbe:
-    httpGet:
-      port: http
-      path: /health
-    periodSeconds: 3
-    failureThreshold: 30
-  readinessProbe:
-    failureThreshold: 3
-    httpGet:
-      path: /health
-      port: http
-      scheme: HTTP
-    periodSeconds: 10
-    successThreshold: 1
-    timeoutSeconds: 10
-  livenessProbe:
-    failureThreshold: 3
-    httpGet:
-      path: /health
-      port: http
-      scheme: HTTP
-    initialDelaySeconds: 120
-    periodSeconds: 15
-    timeoutSeconds: 5
-  annotations: ~
+
   strategy:
+    type: RollingUpdate
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 0%
-    type: RollingUpdate
+
   podDisruptionBudget:
     enabled: true
     minAvailable: 2
+
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -152,59 +242,75 @@ web:
                 app.kubernetes.io/component: web
             topologyKey: kubernetes.io/hostname
 
-translations:
-  enabled: true
-  libretranslate:
-    endpoint: https://translate.mstdn.social/ # FIXME: set to deepl when their system works again
-  # deepl:
-    # plan: free
+  nodeSelector: {}
+  tolerations: []
 
-streaming:
-  image:
-    repository: ghcr.io/mastodon/mastodon-streaming
-    pullPolicy: IfNotPresent
-    tag: v4.5.3@sha256:7340d8b82dde734ddb6e9eee25013f5ea25545c3875fd17cc38e3120fefeeb05
-  replicaCount: 2
-  clusterNum: 1
-  port: 4000
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
-  readinessProbe:
-    failureThreshold: 3
+  startupProbe:
     httpGet:
-      path: /api/v1/streaming/health
-      port: streaming
+      port: http
+      path: /health
+    periodSeconds: 3
+    failureThreshold: 30
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
       scheme: HTTP
     periodSeconds: 10
     successThreshold: 1
-    timeoutSeconds: 10
-  startupProbe:
-    httpGet:
-      port: streaming
-      path: /api/v1/streaming/health
-    periodSeconds: 3
-    failureThreshold: 30
-  livenessProbe:
     failureThreshold: 3
+    timeoutSeconds: 10
+
+  livenessProbe:
     httpGet:
-      path: /api/v1/streaming/health
-      port: streaming
+      path: /health
+      port: http
       scheme: HTTP
     initialDelaySeconds: 120
     periodSeconds: 15
+    failureThreshold: 3
     timeoutSeconds: 5
+
+  annotations: {}
+
+# =============================================================================
+# COMPONENT: STREAMING
+# =============================================================================
+streaming:
+  replicas: 2
+  port: 4000
+  clusterNum: 1
+
+  # Base URL for WebSocket connections
+  baseUrl: wss://streaming.toot.community
+
+  # Streaming has its own image (Node.js)
+  image:
+    repository: ghcr.io/mastodon/mastodon-streaming
+    pullPolicy: IfNotPresent
+    tag: ""  # Set explicitly with digest for pinning
+
+  # Override database SSL mode for streaming
+  databaseSslMode: no-verify
+
   resources:
     requests:
       cpu: 41m
       memory: 100Mi
     limits:
       memory: 100Mi
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
+
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -214,30 +320,83 @@ streaming:
               matchLabels:
                 app.kubernetes.io/component: streaming
             topologyKey: kubernetes.io/hostname
-  podMonitor:
-    enabled: true
-    interval: 30s
-    scrapeTimeout: 10s
-    path: /metrics
-    port: streaming
-    scheme: http
-  annotations: ~
-  redis:
-    url: redis://redis-ha-haproxy:6379
-  baseURL: wss://streaming.toot.community
-  databaseSslMode: no-verify
 
+  nodeSelector: {}
+  tolerations: []
+
+  startupProbe:
+    httpGet:
+      port: streaming
+      path: /api/v1/streaming/health
+    periodSeconds: 3
+    failureThreshold: 30
+
+  readinessProbe:
+    httpGet:
+      path: /api/v1/streaming/health
+      port: streaming
+      scheme: HTTP
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 3
+    timeoutSeconds: 10
+
+  livenessProbe:
+    httpGet:
+      path: /api/v1/streaming/health
+      port: streaming
+      scheme: HTTP
+    initialDelaySeconds: 120
+    periodSeconds: 15
+    failureThreshold: 3
+    timeoutSeconds: 5
+
+  # Streaming-specific PodMonitor override
+  podMonitor:
+    port: streaming
+
+  annotations: {}
+
+# =============================================================================
+# COMPONENT: SIDEKIQ
+# =============================================================================
 sidekiq:
+  # Default settings for all workers
+  defaults:
+    resources:
+      requests:
+        cpu: 125m
+        memory: 541Mi
+      limits:
+        memory: 541Mi
+
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+
   podDisruptionBudget:
     enabled: true
-    maxUnavailable: 1
+    minAvailable: 1
+
   affinity:
-    enabled: true
-    topologyKey: kubernetes.io/hostname
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: sidekiq
+            topologyKey: kubernetes.io/hostname
+
+  nodeSelector: {}
+  tolerations: []
+
   workers:
     - name: generic
+      replicas: 3
       concurrency: 25
-      replicaCount: 3
       queues:
         - default
         - mailers
@@ -251,9 +410,10 @@ sidekiq:
           memory: 541Mi
         limits:
           memory: 541Mi
+
     - name: scheduler
+      replicas: 1
       concurrency: 25
-      replicaCount: 1
       queues:
         - scheduler
       resources:
@@ -263,126 +423,153 @@ sidekiq:
         limits:
           memory: 437Mi
 
+# =============================================================================
+# INGRESS (NGINX INGRESS CONTROLLER)
+# =============================================================================
 ingress:
   web:
     enabled: false
-    maxBodySize: 100m
-    upstreamProxyTimeout: 120
     ingressClassName: nginx
     host: toot.community
-    serviceNameOverride: ~
-    servicePortOverride: ~
-    annotations: 
-      cert-manager.io/cluster-issuer: letsencrypt
-      nginx.ingress.kubernetes.io/ssl-redirect: "true"
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
+    # Service routing override (for cache layers like Varnish)
+    serviceOverride:
+      name: null
+      port: null
+
+    # Nginx-specific settings
+    maxBodySize: 100m
+    proxyTimeout: 120
+
+    # Client certificate verification
     verifyClient:
       enabled: false
       secretName: tootcommunity/tootcommunity-ca-secret
+
+    # WWW to non-WWW redirect
+    wwwRedirect:
+      enabled: true
+
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
     tls:
       - hosts:
           - toot.community
         secretName: toot.community-tls
-    wwwRedirect:
-      enabled: true
+
   streaming:
     enabled: false
-    host: streaming.toot.community
     ingressClassName: nginx
-    annotations: 
+    host: streaming.toot.community
+
+    annotations:
       cert-manager.io/cluster-issuer: letsencrypt
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+
     tls:
       - hosts:
           - streaming.toot.community
         secretName: streaming.toot.community-tls
 
+# =============================================================================
+# GATEWAY API
+# =============================================================================
 gateway:
   enabled: false
-  parentRefs: []
-  web:
-    hostname: ""
-    annotations: {}
-    parentRefs: []
-    wwwRedirect:
-      enabled: ~
-      hostname: ""
-      annotations: {}
-  streaming:
-    hostname: ""
-    annotations: {}
-    parentRefs: []
 
+  # Default parent refs for all routes
+  parentRefs: []
+
+  web:
+    hostname: ""  # Defaults to ingress.web.host
+    parentRefs: []  # Overrides gateway.parentRefs
+    annotations: {}
+
+    wwwRedirect:
+      enabled: false
+      hostname: ""  # Defaults to www.{hostname}
+      annotations: {}
+
+  streaming:
+    hostname: ""  # Defaults to ingress.streaming.host
+    parentRefs: []
+    annotations: {}
+
+# =============================================================================
+# SCHEDULED JOBS (CRONJOBS)
+# =============================================================================
 jobs:
-  annotations: ~
+  # Default resources for all jobs
+  defaults:
+    resources:
+      requests:
+        cpu: 250m
+        memory: 500Mi
+      limits:
+        memory: 750Mi
+
+  annotations: {}
+
   cleanupMedia:
     enabled: true
-    schedule: "0 5 * * *" # every day at 5am
+    schedule: "0 5 * * *"  # Every day at 5am
     days: 7
     resources:
       requests:
         cpu: 250m
-        memory: 750M
+        memory: 750Mi
       limits:
-        memory: 750M
-  statusesRemove:
-    enabled: false
-    schedule: "5 4 * * 6"
-    days: 90
-    resources:
-      requests:
-        cpu: 300m
-        memory: 1500M
-      limits:
-        memory: 1500M
+        memory: 750Mi
+
   cleanupMediaProfiles:
     enabled: true
-    schedule: "0 5 * * *" # every day at 5am
+    schedule: "0 5 * * *"  # Every day at 5am
     days: 14
     resources:
       requests:
         cpu: 1000m
-        memory: 721M
+        memory: 721Mi
       limits:
-        memory: 721M
-  accountsPrune:
-    enabled: false # FIXME: needs to fix indexes before enabling this
-    schedule: "0 2 * * 1" # every monday at 2am
-    resources:
-      requests:
-        cpu: 1033m
-        memory: 584M
-      limits:
-        memory: 584M
+        memory: 721Mi
+
   removePreviewCards:
     enabled: true
-    schedule: "0 5 * * 1" # every monday at 5am
+    schedule: "0 5 * * 1"  # Every Monday at 5am
+    days: 30
     resources:
       requests:
         cpu: 500m
         memory: 400Mi
       limits:
         memory: 400Mi
-    days: 30
-    
-metrics:
-  enabled: true
-  port: 9394
-  podMonitor:
-    enabled: true
-    interval: 30s
-    scrapeTimeout: 10s
-    path: /metrics
-    scheme: http
-  web:
-    detailed: true
-    exporter:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 180M
-        limits:
-          memory: 250M
-  sidekiq:
-    detailed: true
+
+  statusesRemove:
+    enabled: false
+    schedule: "5 4 * * 6"  # Saturday at 4:05am
+    days: 90
+    resources:
+      requests:
+        cpu: 300m
+        memory: 1500Mi
+      limits:
+        memory: 1500Mi
+
+  accountsPrune:
+    enabled: false
+    schedule: "0 2 * * 1"  # Every Monday at 2am
+    resources:
+      requests:
+        cpu: 1033m
+        memory: 584Mi
+      limits:
+        memory: 584Mi
+
+# =============================================================================
+# DEBUG MODE
+# =============================================================================
+debug:
+  enabled: false

--- a/manifests/applications/mastodon/base/helm-values/mastodon.yaml
+++ b/manifests/applications/mastodon/base/helm-values/mastodon.yaml
@@ -1,13 +1,19 @@
-configuration:
-  s3:
-    endpoint: https://fsn1.your-objectstorage.com
-    hostname: fsn1.your-objectstorage.com
-    region: fsn1
-    protocol: https
-    timeouts:
-      open: 10
-      read: 10
-  
+mastodon:
+  allowedPrivateAddresses: "10.0.8.0/21"
+
+redis:
+  url: redis://redis-ha-haproxy:6379
+
+s3:
+  endpoint: https://fsn1.your-objectstorage.com
+  hostname: fsn1.your-objectstorage.com
+  region: fsn1
+  protocol: https
+  timeouts:
+    open: 10
+    read: 10
+
+observability:
   otel:
     enabled: false
     namePrefix: mastodon
@@ -16,8 +22,9 @@ configuration:
 
 ingress:
   web:
-    serviceNameOverride: varnish-for-app
-    servicePortOverride: 80
+    serviceOverride:
+      name: varnish-for-app
+      port: 80
 
 gateway:
   enabled: true

--- a/manifests/applications/mastodon/overlays/microblog.network/helm-values/mastodon.yaml
+++ b/manifests/applications/mastodon/overlays/microblog.network/helm-values/mastodon.yaml
@@ -2,42 +2,42 @@
 .streamingDomain: &streamingDomain streaming.microblog.network
 .staticDomain: &staticDomain static.microblog.network
 
-debug: false
+debug:
+  enabled: false
 
-configuration:
+mastodon:
   localDomain: *instanceDomain
   limitedFederationMode: true
   authorizedFetch: false
-  
-  s3:
-    endpoint: https://36imo.upcloudobjects.com
-    hostname: 36imo.upcloudobjects.com
-    region: auto
-    aliasHost: *staticDomain
-    bucket: microblog-network-assets
-    
-  smtp:
-    domain: *instanceDomain
-    fromAddress: microblog.network Notifications <support@microblog.network>
-    smtpServer: mail.jorijn.com
-    
+  extraEnv: {}
+    # OTEL_RUBY_INSTRUMENTATION_PG_ENABLED: "false"
+
+s3:
+  endpoint: https://36imo.upcloudobjects.com
+  hostname: 36imo.upcloudobjects.com
+  region: auto
+  aliasHost: *staticDomain
+  bucket: microblog-network-assets
+
+smtp:
+  domain: *instanceDomain
+  fromAddress: microblog.network Notifications <support@microblog.network>
+  server: mail.jorijn.com
+
+observability:
   otel:
     enabled: false
     namePrefix: microblog-network
-    
-  extraConfiguration: {}
-    # OTEL_RUBY_INSTRUMENTATION_PG_ENABLED: "false"
-    
+
 web:
-  domain: *instanceDomain
-  replicaCount: 3
+  replicas: 3
   podDisruptionBudget:
     enabled: false
-  
+
 streaming:
-  baseURL: wss://streaming.microblog.network
-  replicaCount: 3
-  
+  baseUrl: wss://streaming.microblog.network
+  replicas: 3
+
 ingress:
   web:
     host: *instanceDomain

--- a/manifests/applications/mastodon/overlays/toot.community/helm-values/mastodon.yaml
+++ b/manifests/applications/mastodon/overlays/toot.community/helm-values/mastodon.yaml
@@ -2,59 +2,60 @@
 .streamingDomain: &streamingDomain streaming.toot.community
 .staticDomain: &staticDomain static.toot.community
 
-debug: false
+debug:
+  enabled: false
 
-configuration:
+mastodon:
   localDomain: *instanceDomain
   limitedFederationMode: false
   authorizedFetch: false
+  extraEnv: {}
+    # OTEL_RUBY_INSTRUMENTATION_PG_ENABLED: "false"
 
-  s3:
-    endpoint: https://36imo.upcloudobjects.com
-    hostname: 36imo.upcloudobjects.com
-    region: auto
-    aliasHost: *staticDomain
-    bucket: toot-community-assets
-    
-  smtp:
-    domain: *instanceDomain
-    fromAddress: toot.community Notifications <support@toot.community>
-    smtpServer: mail.jorijn.com
-    
-  search:
+s3:
+  endpoint: https://36imo.upcloudobjects.com
+  hostname: 36imo.upcloudobjects.com
+  region: auto
+  aliasHost: *staticDomain
+  bucket: toot-community-assets
+
+smtp:
+  domain: *instanceDomain
+  fromAddress: toot.community Notifications <support@toot.community>
+  server: mail.jorijn.com
+
+search:
+  enabled: true
+  preset: small_cluster
+
+database:
+  replica:
     enabled: true
-    preset: small_cluster
-  
-  databaseReplicas:
-    enabled: true
-    
+
+observability:
   otel:
     enabled: false
     namePrefix: toot-community
-    
-  extraConfiguration: {}
-    # OTEL_RUBY_INSTRUMENTATION_PG_ENABLED: "false"
 
 web:
-  domain: *instanceDomain
-  replicaCount: 6
+  replicas: 6
   resources:
     requests:
       cpu: 683m
       memory: 4Gi
     limits:
       memory: 8Gi
-  
+
 streaming:
-  baseURL: wss://streaming.toot.community
-  replicaCount: 3
+  baseUrl: wss://streaming.toot.community
+  replicas: 3
   resources:
     requests:
       cpu: 21m
       memory: 100Mi
     limits:
       memory: 100Mi
-  
+
 ingress:
   web:
     host: *instanceDomain
@@ -73,7 +74,7 @@ sidekiq:
   workers:
     - name: generic
       concurrency: 25
-      replicaCount: 10
+      replicas: 10
       queues:
         - default
         - mailers
@@ -89,7 +90,7 @@ sidekiq:
           memory: 8Gi
     - name: scheduler
       concurrency: 25
-      replicaCount: 1
+      replicas: 1
       queues:
         - scheduler
       resources:
@@ -98,7 +99,7 @@ sidekiq:
           memory: 1Gi
         limits:
           memory: 2Gi
-          
+
 jobs:
   removePreviewCards:
     resources:


### PR DESCRIPTION
## Summary
- Reorganize values.yaml with logical groupings (global, mastodon, database, redis, s3, observability, components)
- Consolidate fragmented database config under `database.{primary,replica,migrations}`
- Unify Redis config with `redis.url` support for streaming
- Move observability settings under `observability.{otel,metrics}`
- Standardize component configs (web, streaming, sidekiq) with consistent patterns
- Fix memory units from `M` to `Mi`
- Normalize sidekiq affinity to full object pattern (was `enabled + topologyKey` shorthand)
- Add `appVersion` to Chart.yaml for proper image tagging

### Review-driven fixes
- Fix Chart.yaml version from `v1.0.0` to `1.0.0` (SemVer standard)
- Add `metrics.enabled` check to PodMonitor templates
- Remove hardcoded toot.community defaults from values.yaml
- Fix image helpers to handle optional component parameter (nil-safe)
- Add securityContext to CronJob and DB migration containers  
- Make probe handling consistent using `with` blocks for nil-safety
- Add `values.schema.json` for IDE validation and autocompletion
- Change retention periods from string to integer with `int64` cast
- Add explicit `enabled` flags for translation providers (libretranslate, deepl)

## Test plan
- [x] `helm lint` passes
- [x] `helm template` renders all resources correctly
- [x] `kubectl diff` against toot.community shows only expected changes (labels, checksum, memory units)
- [x] `kubectl diff` against microblog.network shows only expected changes
- [x] Helm chart reviewed by helm-chart-architect agent
- [ ] Deploy to staging/production and verify pods start correctly