### PR TITLE
fix(mastodon): correct sidekiq affinity selector to use matchExpressions

### DIFF
--- a/charts/mastodon/values.yaml
+++ b/charts/mastodon/values.yaml
@@ -388,8 +388,12 @@ sidekiq:
         - weight: 100
           podAffinityTerm:
             labelSelector:
-              matchLabels:
-                app.kubernetes.io/component: sidekiq
+              matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - sidekiq-generic
+                    - sidekiq-scheduler
             topologyKey: kubernetes.io/hostname
 
   nodeSelector: {}


### PR DESCRIPTION
## Summary
Fix sidekiq pod anti-affinity selector that was not matching any pods.

## Problem
The previous `labelSelector` used:
```yaml
matchLabels:
  app.kubernetes.io/component: sidekiq
```

However, sidekiq pods are labeled with `app.kubernetes.io/component: sidekiq-generic` or `sidekiq-scheduler`, not just `sidekiq`. This means the anti-affinity selector **never matched any pods**, effectively disabling pod spreading.

## Solution
Changed to `matchExpressions` with `In` operator:
```yaml
matchExpressions:
  - key: app.kubernetes.io/component
    operator: In
    values:
      - sidekiq-generic
      - sidekiq-scheduler
```

This ensures all sidekiq pods (generic and scheduler) will spread across nodes.

## Test plan
- [x] `helm template` renders correct affinity with matchExpressions
- [ ] Verify pods spread correctly after deployment