### PR TITLE
feat(robusta): filter email alerts to HIGH and MEDIUM severity

### DIFF
--- a/manifests/applications/robusta/helm-values.yaml
+++ b/manifests/applications/robusta/helm-values.yaml
@@ -42,3 +42,7 @@ sinksConfig:
     aws_region: "eu-west-1"
     from_email: "robusta-alerts@ses.jorijn.com"
     with_header: true
+    scope:
+      include:
+        - severity: HIGH
+        - severity: MEDIUM


### PR DESCRIPTION
## Summary
- Add severity scope filter to the Robusta mail sink configuration
- Only HIGH and MEDIUM severity alerts will be sent via email
- INFO and LOW severity alerts will be ignored to reduce email noise

## Test plan
- [ ] Verify Robusta helm chart deploys successfully
- [ ] Confirm HIGH severity alerts trigger email notifications
- [ ] Confirm INFO/LOW severity alerts do not trigger emails