### PR TITLE
Disable KEDA autoscaling for toot.community web pods and set replicas to 20

### DIFF
--- a/manifests/applications/mastodon/overlays/toot.community/helm-values/mastodon.yaml
+++ b/manifests/applications/mastodon/overlays/toot.community/helm-values/mastodon.yaml
@@ -38,7 +38,7 @@ observability:
     namePrefix: toot-community
 
 web:
-  replicas: 12
+  replicas: 20
   resources:
     requests:
       cpu: 683m
@@ -47,7 +47,7 @@ web:
       memory: 8Gi
   autoscaling:
     keda:
-      enabled: true
+      enabled: false
       minReplicaCount: 6
       maxReplicaCount: 25
       pollingInterval: 15


### PR DESCRIPTION
### Motivation
- Temporarily disable KEDA autoscaling for the toot.community web workload and pin replicas to 20 while dynamic scaling is investigated.

### Description
- Update `manifests/applications/mastodon/overlays/toot.community/helm-values/mastodon.yaml` to set `web.replicas: 20` and `autoscaling.keda.enabled: false`.

### Testing
- No automated tests were run because this is a manifest-only configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822af00d50833191d9ae78c401644b)