### PR TITLE
Increase CrowdSec agent resources and disable VPA

### DIFF
--- a/manifests/applications/crowdsec/helm-values.yaml
+++ b/manifests/applications/crowdsec/helm-values.yaml
@@ -3,10 +3,10 @@ container_runtime: containerd
 agent:
   resources:
     limits:
-      memory: "1Gi"
+      memory: "4Gi"
     requests:
-      cpu: "500m"
-      memory: "500Mi"
+      cpu: "250m"
+      memory: "4Gi"
   acquisition:
     - namespace: traefik-system
       podName: traefik-*

--- a/manifests/applications/vpa-resources/helm-values.yaml
+++ b/manifests/applications/vpa-resources/helm-values.yaml
@@ -169,16 +169,6 @@ vpas:
     resourcePolicy:
       containerPolicies:
         - containerName: "*"
-  - name: crowdsec-agent-vpa
-    namespace: crowdsec
-    targetRef:
-      apiVersion: apps/v1
-      kind: DaemonSet
-      name: crowdsec-agent
-    resourcePolicy:
-      containerPolicies:
-        - containerName: "*"
-          controlledValues: RequestsOnly
   - name: crowdsec-capi-register-job-vpa
     namespace: crowdsec
     targetRef:


### PR DESCRIPTION
**Summary**
- bump the CrowdSec agent to 4 GiB memory limits and requests, and lower the CPU request to 250 m
- remove the CrowdSec agent VPA entry so it no longer overrides the manual resource requirements

**Testing**
- Not run (not requested)