### PR TITLE
[codex] Use local cloudflared chart with secrets and monitoring

### DIFF
--- a/charts/.gitignore
+++ b/charts/.gitignore
@@ -5,4 +5,6 @@
 !varnish/**
 !vpa-resources/
 !vpa-resources/**
+!cloudflare-tunnel-remote/
+!cloudflare-tunnel-remote/**
 !.gitignore

--- a/charts/cloudflare-tunnel-remote/Chart.yaml
+++ b/charts/cloudflare-tunnel-remote/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: latest
+description: Deployment of a remotely managed tunnel that has already been provisioned
+  in Cloudflare
+icon: https://developers.cloudflare.com/cloudflare-one/favicon-32x32.png
+name: cloudflare-tunnel-remote
+type: application
+version: 1.0.0

--- a/charts/cloudflare-tunnel-remote/templates/_helpers.tpl
+++ b/charts/cloudflare-tunnel-remote/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cloudflare-tunnel-remote.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cloudflare-tunnel-remote.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cloudflare-tunnel-remote.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cloudflare-tunnel-remote.labels" -}}
+helm.sh/chart: {{ include "cloudflare-tunnel-remote.chart" . }}
+{{ include "cloudflare-tunnel-remote.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cloudflare-tunnel-remote.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudflare-tunnel-remote.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cloudflare-tunnel-remote.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cloudflare-tunnel-remote.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      pod: cloudflared
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        # Roll the deployment when the secret reference changes.
+        checksum/secret: {{ printf "%s/%s" (required "cloudflare.tunnelTokenSecretName is required" .Values.cloudflare.tunnelTokenSecretName) (.Values.cloudflare.tunnelTokenSecretKey | default "token") | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        pod: cloudflared
+        {{- include "cloudflare-tunnel-remote.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "cloudflare-tunnel-remote.fullname" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: cloudflared
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        command:
+          - cloudflared
+          - tunnel
+          # We can regulate the cloudflared version via an image tag.
+          - --no-autoupdate
+          # In a k8s environment, the metrics server needs to listen outside the pod it runs on.
+          # The address 0.0.0.0:<metrics-port> allows any pod in the namespace.
+          - --metrics
+          - 0.0.0.0:{{ .Values.metrics.port }}
+          - run
+        env:
+        - name: TUNNEL_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "cloudflare.tunnelTokenSecretName is required" .Values.cloudflare.tunnelTokenSecretName }}
+              key: {{ .Values.cloudflare.tunnelTokenSecretKey | default "token" }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metrics.port }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            # Cloudflared has a /ready endpoint which returns 200 if and only if
+            # it has an active connection to the edge.
+            path: /ready
+            port: {{ .Values.metrics.port }}
+          failureThreshold: 1
+          initialDelaySeconds: 10
+          periodSeconds: 10

--- a/charts/cloudflare-tunnel-remote/templates/service.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if or .Values.service.enabled .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
+  selector:
+    {{- include "cloudflare-tunnel-remote.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/templates/serviceaccount.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+# Here we create a service account with no privileges to run the
+# deployment - just in case the default service account is different.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/cloudflare-tunnel-remote/templates/servicemonitor.yaml
+++ b/charts/cloudflare-tunnel-remote/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cloudflare-tunnel-remote.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-remote.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cloudflare-tunnel-remote.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      path: {{ .Values.serviceMonitor.path }}
+      scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/cloudflare-tunnel-remote/values.yaml
+++ b/charts/cloudflare-tunnel-remote/values.yaml
@@ -1,0 +1,87 @@
+# Default values for cloudflare-tunnel.
+
+# Cloudflare parameters.
+cloudflare:
+  # Name of an existing secret that contains the tunnel token.
+  tunnelTokenSecretName: ""
+  # Key within the secret that contains the tunnel token.
+  tunnelTokenSecretKey: "token"
+
+metrics:
+  port: 2000
+
+service:
+  enabled: false
+  type: ClusterIP
+  annotations: {}
+  labels: {}
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /metrics
+  scheme: http
+  additionalLabels: {}
+  relabelings: []
+  metricRelabelings: []
+
+image:
+  repository: cloudflare/cloudflared
+  pullPolicy: IfNotPresent
+  # If supplied, this overrides "latest"
+  tag: ""
+
+replicaCount: 2
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+# Security items common to everything in the pod.  Here we require that it
+# does not run as the user defined in the image, literally named "nonroot".
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# Security items for one container. We lock it down.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+# Default affinity is to spread out over nodes; use this to override.
+affinity: {}

--- a/manifests/applications/argocd/applications/cloudflared.yaml
+++ b/manifests/applications/argocd/applications/cloudflared.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloudflared
+  namespace: argocd
+spec:
+  destination:
+    namespace: cloudflare
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: manifests/applications/cloudflared
+    repoURL: git@github.com:toot-community/platform.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true

--- a/manifests/applications/argocd/applications/kustomization.yaml
+++ b/manifests/applications/argocd/applications/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - argocd.yaml
+  - cloudflared.yaml
   - cert-manager.yaml
   - cilium.yaml
   - cloudnative-pg.yaml

--- a/manifests/applications/cloudflared/cloudflared-private-pdb.yaml
+++ b/manifests/applications/cloudflared/cloudflared-private-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflared-admin
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflared-admin

--- a/manifests/applications/cloudflared/cloudflared-private-secret.yaml
+++ b/manifests/applications/cloudflared/cloudflared-private-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflared-private-credentials
+spec:
+  itemPath: vaults/toot.community/items/w2mp4dfbxw7emhhmbjhumxp3ca

--- a/manifests/applications/cloudflared/cloudflared-public-pdb.yaml
+++ b/manifests/applications/cloudflared/cloudflared-public-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cloudflared-public
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflare-tunnel
+      app.kubernetes.io/instance: cloudflared-public

--- a/manifests/applications/cloudflared/cloudflared-public-secret.yaml
+++ b/manifests/applications/cloudflared/cloudflared-public-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflared-public-credentials
+spec:
+  itemPath: vaults/toot.community/items/ls43sgvmj2dpj57aqh57idicqy

--- a/manifests/applications/cloudflared/helm-values-private.yaml
+++ b/manifests/applications/cloudflared/helm-values-private.yaml
@@ -1,0 +1,43 @@
+replicaCount: 3
+
+cloudflare:
+  tunnelTokenSecretName: cloudflared-private-credentials
+  tunnelTokenSecretKey: token
+
+serviceMonitor:
+  enabled: true
+
+fullnameOverride: cloudflared-private
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 128Mi
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudflare-tunnel
+              app.kubernetes.io/instance: cloudflared-private
+          topologyKey: kubernetes.io/hostname

--- a/manifests/applications/cloudflared/helm-values-public.yaml
+++ b/manifests/applications/cloudflared/helm-values-public.yaml
@@ -1,0 +1,43 @@
+replicaCount: 3
+
+cloudflare:
+  tunnelTokenSecretName: cloudflared-public-credentials
+  tunnelTokenSecretKey: token
+
+serviceMonitor:
+  enabled: true
+
+fullnameOverride: cloudflared-public
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 128Mi
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudflare-tunnel
+              app.kubernetes.io/instance: cloudflared-public
+          topologyKey: kubernetes.io/hostname

--- a/manifests/applications/cloudflared/kustomization.yaml
+++ b/manifests/applications/cloudflared/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cloudflare
+
+helmGlobals:
+  chartHome: ../../../charts
+
+resources:
+  - namespace.yaml
+  - cloudflared-public-pdb.yaml
+  - cloudflared-public-secret.yaml
+  - cloudflared-private-pdb.yaml
+  - cloudflared-private-secret.yaml
+
+helmCharts:
+  - name: cloudflare-tunnel-remote
+    version: "0.0.0"
+    releaseName: cloudflared-public
+    namespace: cloudflare
+    valuesFile: helm-values-public.yaml
+  - name: cloudflare-tunnel-remote
+    version: "0.0.0"
+    releaseName: cloudflared-private
+    namespace: cloudflare
+    valuesFile: helm-values-private.yaml
+
+# patches:
+#   # - path: patches/cloudflared-public-topology.yaml
+#   # - path: patches/cloudflared-private-topology.yaml
+#   - target:
+#       kind: Deployment
+#       name: cloudflared-public
+#     patch: |-
+#       - op: add
+#         path: /spec/template/spec/containers/0/args/-
+#         value: --protocol
+#       - op: add
+#         path: /spec/template/spec/containers/0/args/-
+#         value: http2
+#   - target:
+#       kind: Deployment
+#       name: cloudflared-private
+#     patch: |-
+#       - op: add
+#         path: /spec/template/spec/containers/0/args/-
+#         value: --protocol
+#       - op: add
+#         path: /spec/template/spec/containers/0/args/-
+#         value: http2
+
+images:
+  - name: cloudflare/cloudflared
+    newTag: "2026.1.2"

--- a/manifests/applications/cloudflared/namespace.yaml
+++ b/manifests/applications/cloudflared/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflare

--- a/manifests/applications/cloudflared/patches/cloudflared-admin-topology.yaml
+++ b/manifests/applications/cloudflared/patches/cloudflared-admin-topology.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-admin
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudflare-tunnel
+              app.kubernetes.io/instance: cloudflared-admin

--- a/manifests/applications/cloudflared/patches/cloudflared-public-topology.yaml
+++ b/manifests/applications/cloudflared/patches/cloudflared-public-topology.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-public
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudflare-tunnel
+              app.kubernetes.io/instance: cloudflared-public


### PR DESCRIPTION
## Summary
- use the local cloudflared chart and point deployments at 1Password-managed tunnel token secrets
- add metrics Service + ServiceMonitor support for cloudflared
- wire pod/container security contexts to satisfy PodSecurity restricted

## Problem
Cloudflared was still using the upstream chart and required inline tunnel tokens, while 1Password secrets were already defined but unused. The deployment also lacked ServiceMonitor wiring for metrics and triggered PodSecurity restricted warnings due to missing security context settings.

## Root Cause
The kustomization referenced the remote chart and the local chart template never applied pod/container security context values or emitted ServiceMonitor resources.

## Fix
The kustomization now uses the local chart, tunnel tokens are read from existing secrets (key `token`), a metrics Service and ServiceMonitor are added, and security contexts are applied with restricted-safe defaults.

## Tests
Not run (manifests-only change).
